### PR TITLE
v1.5.0 — Sync VSCode improvements, simplified settings, broader compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add Apple Chinese input method detection on macOS.
 - Improve Linux keyboard layout detection for GNOME-based distributions.
 - Fix Chinese input methods displaying "cn" instead of "zh".
+- Replace deprecated `IdeEventQueue.addDispatcher` with `addPostprocessor` for IntelliJ 2026.1 compatibility.
 
 ## [1.4.8]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.5.0]
+
+### Changed
+
+- Simplify settings: remove font, opacity, and position options (auto-derived from editor).
+- Separate cursor color and text indicator color into independent settings.
+- Add text indicator background color option.
+- Add Apple Chinese input method detection on macOS.
+- Improve Linux keyboard layout detection for GNOME-based distributions.
+- Fix Chinese input methods displaying "cn" instead of "zh".
+
 ## [1.4.8]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Improve Linux keyboard layout detection for GNOME-based distributions.
 - Fix Chinese input methods displaying "cn" instead of "zh".
 - Replace deprecated `IdeEventQueue.addDispatcher` with `addPostprocessor` for IntelliJ 2026.1 compatibility.
+- Add support for IntelliJ IDEA 2026.1.
+- Remove `pluginUntilBuild` to support all future IDE versions automatically.
 
 ## [1.4.8]
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,10 @@ This feature is particularly beneficial for developers juggling multiple languag
 
 ### Features
 - **🎨 Cursor Color Change:** Automatically changes the cursor color based on the current language.
-- **🔤 Language Indicator:** Displays the current language on the cursor.
+- **🔤 Language Indicator:** Displays the current language on the cursor with customizable text and background colors.
 - **🔒 Caps Lock Indicator:** Shows the Caps Lock status on the cursor.
-- **🔧 Customization:** Customize the language indicator's font, size, opacity, and position.
-- **🖥️ Supported Operating Systems:** Available on Windows, Mac, and Linux.
-- **🌐 Supported Languages And Input Methods:** Supports a wide range of languages and input methods, including [Sogou Pinyin](https://pinyin.sogou.com/mac) and [Squirrel](https://rime.im) Zhuyin methods on macOS.
+- **🖥️ Supported Operating Systems:** Available on Windows, Mac, and Linux (including GNOME-based distributions).
+- **🌐 Supported Languages And Input Methods:** Supports a wide range of languages and input methods, including Apple Chinese input methods, [Sogou Pinyin](https://pinyin.sogou.com/mac), and [Squirrel](https://rime.im) Zhuyin methods on macOS.
 
 
 ## Usage
@@ -50,15 +49,12 @@ You can customize Kursor's settings to suit your preferences:
 
 ### Settings
 - **Default Language:** The default language for your IDE.
-- **Change Color on Non-Default Language:** Changes the cursor color if the language is not the default.
+- **Cursor Color:** The cursor color when a non-default language is active. Leave empty to disable color change.
 - **Show Text Indicator:** Displays a language indicator on the cursor. If disabled, only the cursor color will be changed.
 - **Show Default Language:** Shows the default language on the cursor when enabled.
 - **Indicate Caps Lock:** Displays a Caps Lock indicator on the cursor. The language will be shown in uppercase.
-- **Font:** The font used for the language indicator.
-- **Size:** Font size of the language indicator.
-- **Opacity:** Opacity of the language indicator (0 - transparent, 255 - opaque).
-- **Vertical Position:** Vertical position of the language indicator (top, middle, or bottom).
-- **Horizontal Offset:** Horizontal offset of the language indicator.
+- **Text Color:** The color of the language indicator text.
+- **Background Color:** Optional background color behind the language indicator. Leave empty for no background.
 
 
 ## Feedback and Suggestions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = provider { null }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.siropkin.kursor
 pluginName = Kursor
 pluginRepositoryUrl = https://github.com/siropkin/kursor
 # SemVer format -> https://semver.org
-pluginVersion = 1.4.8
+pluginVersion = 1.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 1.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251
-pluginUntilBuild = 253.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC

--- a/src/main/kotlin/com/github/siropkin/kursor/KursorSettings.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/KursorSettings.kt
@@ -4,12 +4,10 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
-import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.util.xmlb.Converter
 import com.intellij.util.xmlb.XmlSerializerUtil
 import com.intellij.util.xmlb.annotations.OptionTag
 import java.awt.Color
-import java.awt.Font
 
 
 @State(
@@ -19,22 +17,18 @@ import java.awt.Font
 class KursorSettings : PersistentStateComponent<KursorSettings> {
     var defaultLanguage: String = "us"
 
-    var changeColorOnNonDefaultLanguage: Boolean = true
-    @OptionTag("colorOnNonDefaultLanguage_", converter = ColorConverter::class)
-    var colorOnNonDefaultLanguage: Color = Color(255, 140, 0)
+    @OptionTag("cursorColor_", converter = NullableColorConverter::class)
+    var cursorColor: Color? = Color(255, 140, 0)
 
     var showTextIndicator: Boolean = true
-
-    var textIndicatorFontName: String = EditorColorsManager.getInstance().globalScheme.editorFontName
-    var textIndicatorFontStyle: Int = Font.PLAIN
-    var textIndicatorFontSize: Int = 11
-    var textIndicatorFontAlpha: Int = 180
-
-    var textIndicatorVerticalPosition: String = TextIndicatorVerticalPositions.TOP
-    var textIndicatorHorizontalOffset: Int = 4
-
     var indicateCapsLock: Boolean = true
     var indicateDefaultLanguage: Boolean = false
+
+    @OptionTag("textIndicatorColor_", converter = ColorConverter::class)
+    var textIndicatorColor: Color = Color(255, 140, 0)
+
+    @OptionTag("textIndicatorBackgroundColor_", converter = NullableColorConverter::class)
+    var textIndicatorBackgroundColor: Color? = null
 
     override fun getState(): KursorSettings {
         return this
@@ -58,10 +52,23 @@ class KursorSettings : PersistentStateComponent<KursorSettings> {
 class ColorConverter : Converter<Color>() {
     override fun fromString(value: String): Color {
         val parts = value.split(",")
-        return Color(parts[0].toInt(), parts[1].toInt(), parts[2].toInt(), parts[3].toInt())
+        return Color(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
     }
 
     override fun toString(value: Color): String {
-        return "${value.red},${value.green},${value.blue},${value.alpha}"
+        return "${value.red},${value.green},${value.blue}"
+    }
+}
+
+class NullableColorConverter : Converter<Color?>() {
+    override fun fromString(value: String): Color? {
+        if (value.isBlank()) return null
+        val parts = value.split(",")
+        return Color(parts[0].toInt(), parts[1].toInt(), parts[2].toInt())
+    }
+
+    override fun toString(value: Color?): String {
+        if (value == null) return ""
+        return "${value.red},${value.green},${value.blue}"
     }
 }

--- a/src/main/kotlin/com/github/siropkin/kursor/KursorSettingsComponent.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/KursorSettingsComponent.kt
@@ -1,14 +1,15 @@
 package com.github.siropkin.kursor
 
 import com.github.siropkin.kursor.keyboard.Keyboard
-import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.ColorPanel
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.JBUI
-import java.awt.*
+import java.awt.Color
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
 import javax.swing.BoxLayout
 import javax.swing.JButton
 import javax.swing.JComponent
@@ -24,26 +25,18 @@ class KursorSettingsComponent {
     private val defaultLanguageComponent = JBTextField("", 5)
     private val detectKeyboardLayoutButton = JButton("Detect Keyboard Layout")
 
-    private val changeColorOnNonDefaultLanguageComponent = JBCheckBox("Change color on non-default language")
-    private val colorOnNonDefaultLanguageComponent = ColorPanel()
+    private val cursorColorComponent = ColorPanel()
 
     private val showTextIndicatorComponent = JBCheckBox("Show text indicator")
-    private val indicateCapsLockComponent = JBCheckBox("Indicate 'Caps Lock'")
     private val indicateDefaultLanguageComponent = JBCheckBox("Show default language")
-
-    private val textIndicatorFontNameComponent = ComboBox(GraphicsEnvironment.getLocalGraphicsEnvironment().availableFontFamilyNames)
-    private val textIndicatorFontStyleComponent = ComboBox(arrayOf(Font.PLAIN.toString(), Font.BOLD.toString(), Font.ITALIC.toString()))
-    private val textIndicatorFontSizeComponent = JBTextField()
-    private val textIndicatorFontAlphaComponent = JBTextField()
-
-    private val textIndicatorVerticalPositionComponent = ComboBox(arrayOf(TextIndicatorVerticalPositions.TOP, TextIndicatorVerticalPositions.MIDDLE, TextIndicatorVerticalPositions.BOTTOM))
-    private val textIndicatorHorizontalOffsetComponent = JBTextField()
+    private val indicateCapsLockComponent = JBCheckBox("Indicate 'Caps Lock'")
+    private val textIndicatorColorComponent = ColorPanel()
+    private val textIndicatorBackgroundColorComponent = ColorPanel()
 
     var panel: JPanel = FormBuilder.createFormBuilder()
         .addComponent(createLanguagePanel())
-        .addComponent(createColorPanel())
+        .addComponent(createCursorPanel())
         .addComponent(createIndicatorPanel())
-        .addComponent(createPositionPanel())
         .addComponentFillVertically(JPanel(), 0)
         .panel
 
@@ -56,18 +49,10 @@ class KursorSettingsComponent {
             defaultLanguageComponent.text = value.lowercase()
         }
 
-    var changeColorOnNonDefaultLanguage: Boolean
-        get() = changeColorOnNonDefaultLanguageComponent.isSelected
+    var cursorColor: Color?
+        get() = cursorColorComponent.selectedColor
         set(value) {
-            changeColorOnNonDefaultLanguageComponent.isSelected = value
-        }
-
-    var colorOnNonDefaultLanguage: Color?
-        get() = colorOnNonDefaultLanguageComponent.selectedColor
-        set(value) {
-            value?.let {
-                colorOnNonDefaultLanguageComponent.selectedColor = Color(it.red, it.green, it.blue)
-            }
+            cursorColorComponent.selectedColor = value
         }
 
     var showTextIndicator: Boolean
@@ -88,55 +73,16 @@ class KursorSettingsComponent {
             indicateDefaultLanguageComponent.isSelected = value
         }
 
-    var textIndicatorFontName: String
-        get() = textIndicatorFontNameComponent.selectedItem as String
+    var textIndicatorColor: Color?
+        get() = textIndicatorColorComponent.selectedColor
         set(value) {
-            textIndicatorFontNameComponent.selectedItem = value
+            textIndicatorColorComponent.selectedColor = value
         }
 
-    var textIndicatorFontStyle: Int
-        get() = (textIndicatorFontStyleComponent.selectedItem as String).toInt()
+    var textIndicatorBackgroundColor: Color?
+        get() = textIndicatorBackgroundColorComponent.selectedColor
         set(value) {
-            textIndicatorFontStyleComponent.selectedItem = value.toString()
-        }
-
-    var textIndicatorFontSize: Int
-        get() = textIndicatorFontSizeComponent.text.toInt()
-        set(value) {
-            try {
-                val intValue = Integer.parseInt(value.toString())
-                textIndicatorFontSizeComponent.text = intValue.coerceAtLeast(5).coerceAtMost(20).toString()
-            } catch (_: NumberFormatException) {
-                // indicatorFontSizeComponent.text = ""
-            }
-        }
-
-    var textIndicatorFontAlpha: Int
-        get() = textIndicatorFontAlphaComponent.text.toInt()
-        set(value) {
-            try {
-                val intValue = Integer.parseInt(value.toString())
-                textIndicatorFontAlphaComponent.text = intValue.coerceAtLeast(0).coerceAtMost(255).toString()
-            } catch (_: NumberFormatException) {
-                // indicatorFontAlphaComponent.text = ""
-            }
-        }
-
-    var textIndicatorVerticalPosition: String
-        get() = textIndicatorVerticalPositionComponent.selectedItem as String
-        set(value) {
-            textIndicatorVerticalPositionComponent.selectedItem = value
-        }
-
-    var textIndicatorHorizontalOffset: Int
-        get() = textIndicatorHorizontalOffsetComponent.text.toInt()
-        set(value) {
-            try {
-                val intValue = Integer.parseInt(value.toString())
-                textIndicatorHorizontalOffsetComponent.text = intValue.coerceAtLeast(-10).coerceAtMost(10).toString()
-            } catch (_: NumberFormatException) {
-                // indicatorHorizontalOffsetComponent.text = ""
-            }
+            textIndicatorBackgroundColorComponent.selectedColor = value
         }
 
     private fun createLanguagePanel(): JPanel {
@@ -153,17 +99,13 @@ class KursorSettingsComponent {
         return languagePanel
     }
 
-    private fun createColorPanel(): JPanel {
-        val colorPanel = JPanel()
-        colorPanel.layout = GridBagLayout()
-        colorPanel.add(changeColorOnNonDefaultLanguageComponent, createRbc(0, 0, 0.0))
-        colorPanel.add(colorOnNonDefaultLanguageComponent, createRbc(1, 0, 1.0, LABEL_SPACING))
+    private fun createCursorPanel(): JPanel {
+        val cursorPanel = JPanel()
+        cursorPanel.layout = GridBagLayout()
+        cursorPanel.add(JBLabel("Cursor color:"), createRbc(0, 0, 0.0))
+        cursorPanel.add(cursorColorComponent, createRbc(1, 0, 1.0, LABEL_SPACING))
 
-        changeColorOnNonDefaultLanguageComponent.addChangeListener {
-            colorOnNonDefaultLanguageComponent.isEnabled = changeColorOnNonDefaultLanguage
-        }
-
-        return colorPanel
+        return cursorPanel
     }
 
     private fun createIndicatorPanel(): JPanel {
@@ -173,46 +115,27 @@ class KursorSettingsComponent {
         checkBoxPanel.add(indicateDefaultLanguageComponent, createRbc(1, 0, 0.0, COMPONENT_SPACING))
         checkBoxPanel.add(indicateCapsLockComponent, createRbc(2, 0, 1.0, COMPONENT_SPACING))
 
-        val fontPanel = JPanel()
-        fontPanel.layout = GridBagLayout()
-        fontPanel.add(JBLabel("Font:"), createRbc(0, 0, 0.0))
-        fontPanel.add(textIndicatorFontNameComponent, createRbc(1, 0, 0.0, LABEL_SPACING))
-        fontPanel.add(JBLabel("Size:"), createRbc(2, 0, 0.0, COMPONENT_SPACING))
-        fontPanel.add(textIndicatorFontSizeComponent, createRbc(3, 0, 0.0, LABEL_SPACING))
-        fontPanel.add(JBLabel("Opacity:"), createRbc(4, 0, 0.0, COMPONENT_SPACING))
-        fontPanel.add(textIndicatorFontAlphaComponent, createRbc(5, 0, 1.0, LABEL_SPACING))
+        val colorPanel = JPanel()
+        colorPanel.layout = GridBagLayout()
+        colorPanel.add(JBLabel("Text color:"), createRbc(0, 0, 0.0))
+        colorPanel.add(textIndicatorColorComponent, createRbc(1, 0, 0.0, LABEL_SPACING))
+        colorPanel.add(JBLabel("Background color:"), createRbc(2, 0, 0.0, COMPONENT_SPACING))
+        colorPanel.add(textIndicatorBackgroundColorComponent, createRbc(3, 0, 1.0, LABEL_SPACING))
 
         showTextIndicatorComponent.addChangeListener {
-            indicateDefaultLanguageComponent.isEnabled = showTextIndicator
-            indicateCapsLockComponent.isEnabled = showTextIndicator
-            textIndicatorFontNameComponent.isEnabled = showTextIndicator
-            textIndicatorFontStyleComponent.isEnabled = showTextIndicator
-            textIndicatorFontSizeComponent.isEnabled = showTextIndicator
-            textIndicatorFontAlphaComponent.isEnabled = showTextIndicator
-            textIndicatorVerticalPositionComponent.isEnabled = showTextIndicator
-            textIndicatorHorizontalOffsetComponent.isEnabled = showTextIndicator
+            val enabled = showTextIndicator
+            indicateDefaultLanguageComponent.isEnabled = enabled
+            indicateCapsLockComponent.isEnabled = enabled
+            textIndicatorColorComponent.isEnabled = enabled
+            textIndicatorBackgroundColorComponent.isEnabled = enabled
         }
 
         val container = JPanel()
         container.layout = BoxLayout(container, BoxLayout.Y_AXIS)
         container.add(checkBoxPanel)
-        container.add(fontPanel)
+        container.add(colorPanel)
 
         return container
-    }
-
-    private fun createPositionPanel(): JPanel {
-        val positionPanel = JPanel()
-        positionPanel.layout = GridBagLayout()
-        positionPanel.add(JBLabel("Vertical position:"), createRbc(0, 0, 0.0))
-        positionPanel.add(textIndicatorVerticalPositionComponent, createRbc(1, 0, 0.0, LABEL_SPACING))
-        positionPanel.add(JBLabel("Horizontal offset:"), createRbc(2, 0, 0.0, COMPONENT_SPACING))
-        positionPanel.add(textIndicatorHorizontalOffsetComponent, createRbc(3, 0, 1.0, LABEL_SPACING))
-
-        textIndicatorVerticalPositionComponent.maximumSize = Dimension(200, textIndicatorVerticalPositionComponent.preferredSize.height)
-        textIndicatorHorizontalOffsetComponent.maximumSize = Dimension(100, textIndicatorHorizontalOffsetComponent.preferredSize.height)
-
-        return positionPanel
     }
 
     private fun createRbc(x: Int, y: Int, weightx: Double): GridBagConstraints {

--- a/src/main/kotlin/com/github/siropkin/kursor/KursorSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/KursorSettingsConfigurable.kt
@@ -24,17 +24,12 @@ class KursorSettingsConfigurable: Configurable {
         val settings = KursorSettings.getInstance()
         settingsComponent?.let {
             return it.defaultLanguage != settings.defaultLanguage
-                    || it.changeColorOnNonDefaultLanguage != settings.changeColorOnNonDefaultLanguage
-                    || it.colorOnNonDefaultLanguage != settings.colorOnNonDefaultLanguage
+                    || it.cursorColor != settings.cursorColor
                     || it.showTextIndicator != settings.showTextIndicator
                     || it.indicateCapsLock != settings.indicateCapsLock
                     || it.indicateDefaultLanguage != settings.indicateDefaultLanguage
-                    || it.textIndicatorFontName != settings.textIndicatorFontName
-                    || it.textIndicatorFontStyle != settings.textIndicatorFontStyle
-                    || it.textIndicatorFontSize != settings.textIndicatorFontSize
-                    || it.textIndicatorFontAlpha != settings.textIndicatorFontAlpha
-                    || it.textIndicatorVerticalPosition != settings.textIndicatorVerticalPosition
-                    || it.textIndicatorHorizontalOffset != settings.textIndicatorHorizontalOffset
+                    || it.textIndicatorColor != settings.textIndicatorColor
+                    || it.textIndicatorBackgroundColor != settings.textIndicatorBackgroundColor
         }
         return false
     }
@@ -42,34 +37,24 @@ class KursorSettingsConfigurable: Configurable {
     override fun apply() {
         val settings = KursorSettings.getInstance()
         settings.defaultLanguage = settingsComponent!!.defaultLanguage
-        settings.changeColorOnNonDefaultLanguage = settingsComponent!!.changeColorOnNonDefaultLanguage
-        settings.colorOnNonDefaultLanguage = settingsComponent!!.colorOnNonDefaultLanguage!!
+        settings.cursorColor = settingsComponent!!.cursorColor
         settings.showTextIndicator = settingsComponent!!.showTextIndicator
         settings.indicateCapsLock = settingsComponent!!.indicateCapsLock
         settings.indicateDefaultLanguage = settingsComponent!!.indicateDefaultLanguage
-        settings.textIndicatorFontName = settingsComponent!!.textIndicatorFontName
-        settings.textIndicatorFontStyle = settingsComponent!!.textIndicatorFontStyle
-        settings.textIndicatorFontSize = settingsComponent!!.textIndicatorFontSize
-        settings.textIndicatorFontAlpha = settingsComponent!!.textIndicatorFontAlpha
-        settings.textIndicatorVerticalPosition = settingsComponent!!.textIndicatorVerticalPosition
-        settings.textIndicatorHorizontalOffset = settingsComponent!!.textIndicatorHorizontalOffset
+        settings.textIndicatorColor = settingsComponent!!.textIndicatorColor ?: settings.textIndicatorColor
+        settings.textIndicatorBackgroundColor = settingsComponent!!.textIndicatorBackgroundColor
     }
 
     override fun reset() {
         val settings = KursorSettings.getInstance()
         settingsComponent?.let {
             it.defaultLanguage = settings.defaultLanguage
-            it.changeColorOnNonDefaultLanguage = settings.changeColorOnNonDefaultLanguage
-            it.colorOnNonDefaultLanguage = settings.colorOnNonDefaultLanguage
+            it.cursorColor = settings.cursorColor
             it.showTextIndicator = settings.showTextIndicator
             it.indicateCapsLock = settings.indicateCapsLock
             it.indicateDefaultLanguage = settings.indicateDefaultLanguage
-            it.textIndicatorFontName = settings.textIndicatorFontName
-            it.textIndicatorFontStyle = settings.textIndicatorFontStyle
-            it.textIndicatorFontSize = settings.textIndicatorFontSize
-            it.textIndicatorFontAlpha = settings.textIndicatorFontAlpha
-            it.textIndicatorVerticalPosition = settings.textIndicatorVerticalPosition
-            it.textIndicatorHorizontalOffset = settings.textIndicatorHorizontalOffset
+            it.textIndicatorColor = settings.textIndicatorColor
+            it.textIndicatorBackgroundColor = settings.textIndicatorBackgroundColor
         }
     }
 

--- a/src/main/kotlin/com/github/siropkin/kursor/KursorStartupActivity.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/KursorStartupActivity.kt
@@ -40,7 +40,7 @@ class KursorStartupActivity: ProjectActivity {
         }, project)
 
         // add key listener
-        IdeEventQueue.getInstance().addDispatcher({ event ->
+        IdeEventQueue.getInstance().addPostprocessor({ event ->
             if (event is KeyEvent) {
                 kursors.forEach { (_, kursor) -> kursor.repaint() }
             }

--- a/src/main/kotlin/com/github/siropkin/kursor/TextIndicatorVerticalPositions.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/TextIndicatorVerticalPositions.kt
@@ -1,7 +1,0 @@
-package com.github.siropkin.kursor
-
-object TextIndicatorVerticalPositions {
-    const val TOP = "top"
-    const val MIDDLE = "middle"
-    const val BOTTOM = "bottom"
-}

--- a/src/main/kotlin/com/github/siropkin/kursor/keyboard/Keyboard.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/keyboard/Keyboard.kt
@@ -36,13 +36,13 @@ class Keyboard {
         // For Linux we know only keyboard layout and do not know keyboard language
         val config = linuxConfig ?: return getUnknownLayout()
         return when {
-            config.distribution == "ubuntu" -> getUbuntuLayout()
+            config.distribution.startsWith("ubuntu") || config.desktopEnvironment.contains("gnome") -> getGnomeLayout()
             config.desktopGroup == "wayland" -> getWaylandLayout()
             else -> getOtherLinuxLayout()
         }
     }
 
-    private fun getUbuntuLayout(): KeyboardLayout {
+    private fun getGnomeLayout(): KeyboardLayout {
         // Output example: [('xkb', 'us'), ('xkb', 'ru'), ('xkb', 'ca+eng')]
         val split = Utils.executeNativeCommand(arrayOf("gsettings", "get", "org.gnome.desktop.input-sources", "mru-sources"))
             .substringAfter("('xkb', '")
@@ -126,9 +126,10 @@ class Keyboard {
         val locale = InputContext.getInstance().locale
         val localeVariant = locale.variant.removePrefix("UserDefined_")
         val variant = MacStandardKeyboardVariants[localeVariant]
+            ?: MacAppleChineseVariants[localeVariant]
             ?: MacSogouPinyinVariants[localeVariant]
             ?: MacRimeSquirrelVariants[localeVariant]
-            ?: ""
+            ?: if (locale.language == "zh") "ZH" else ""
         return KeyboardLayout(locale.language, locale.country, variant)
     }
 

--- a/src/main/kotlin/com/github/siropkin/kursor/keyboard/LinuxConfig.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/keyboard/LinuxConfig.kt
@@ -3,5 +3,6 @@ package com.github.siropkin.kursor.keyboard
 class LinuxConfig {
     var distribution: String = System.getenv("DESKTOP_SESSION")?.lowercase() ?: ""
     var desktopGroup: String = System.getenv("XDG_SESSION_TYPE")?.lowercase() ?: ""
+    var desktopEnvironment: String = System.getenv("XDG_CURRENT_DESKTOP")?.lowercase() ?: ""
     var availableKeyboardLayouts: List<String> = emptyList()
 }

--- a/src/main/kotlin/com/github/siropkin/kursor/keyboard/MacKeyboardVariants.kt
+++ b/src/main/kotlin/com/github/siropkin/kursor/keyboard/MacKeyboardVariants.kt
@@ -14,6 +14,18 @@ val MacSogouPinyinVariants = mapOf(
     "com.sogou.inputmethod.pinyin" to "ZH"
 )
 
+// Apple Chinese Input Methods
+val MacAppleChineseVariants = mapOf(
+    "com.apple.inputmethod.SCIM" to "ZH",
+    "com.apple.inputmethod.SCIM.ITABC" to "ZH",
+    "com.apple.inputmethod.SCIM.WBX" to "ZH",
+    "com.apple.inputmethod.SCIM.Shuangpin" to "ZH",
+    "com.apple.inputmethod.TCIM" to "ZH",
+    "com.apple.inputmethod.TCIM.Zhuyin" to "ZH",
+    "com.apple.inputmethod.TCIM.Cangjie" to "ZH",
+    "com.apple.inputmethod.TCIM.Pinyin" to "ZH",
+)
+
 // Rime Squirrel Layouts https://rime.im
 val MacRimeSquirrelVariants = mapOf(
     "im.rime.inputmethod.Squirrel.Hans" to "ZH", // Simplified


### PR DESCRIPTION
## Summary

- Simplify settings: remove font, opacity, and position options (auto-derived from editor)
- Separate cursor color and text indicator color into independent settings
- Add text indicator background color option
- Add Apple Chinese input method detection on macOS
- Fix Chinese input methods displaying "cn" instead of "zh"
- Improve Linux keyboard layout detection for GNOME-based distributions
- Replace deprecated `IdeEventQueue.addDispatcher` with `addPostprocessor`
- Remove `pluginUntilBuild` to support all future IDE versions automatically

## Test plan

- [x] `./gradlew buildPlugin` passes
- [x] Manual testing in sandbox IDE — settings UI, cursor color, text indicator, background color, keyboard switching all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)